### PR TITLE
Support the optional order argument on the sort() array expression

### DIFF
--- a/src/api/expressions/array.ts
+++ b/src/api/expressions/array.ts
@@ -56,8 +56,14 @@ export function reverse(input: ArrayInput): ReverseExpression {
     return new ReverseExpression(`reverse(${resolveInput(input)})`);
 }
 
-export function sort(input: ArrayInput): SortExpression {
-    return new SortExpression(`sort(${resolveInput(input)})`);
+export function sort(input: ArrayInput, order?: 'asc' | 'desc'): SortExpression {
+    const inputStr = resolveInput(input);
+
+    if (order !== undefined) {
+        return new SortExpression(`sort(${inputStr}, '${order}')`);
+    }
+
+    return new SortExpression(`sort(${inputStr})`);
 }
 
 export function uniq(input: ArrayInput): UniqExpression {

--- a/test/api/expressions/array.test.ts
+++ b/test/api/expressions/array.test.ts
@@ -120,6 +120,16 @@ describe('array tests', (): void => {
             const result = sort(fromJson(hyphenatedExpressionArgs));
             expect(result.toString()).to.equal(`sort(fromJSON(tasks['A-1'].outputs.parameters['output-1']))`);
         });
+
+        it('returns successfully with descending order', (): void => {
+            const result = sort(hyphenatedExpressionArgs, 'desc');
+            expect(result.toString()).to.equal(`sort(tasks['A-1'].outputs.parameters['output-1'], 'desc')`);
+        });
+
+        it('returns successfully with ascending order', (): void => {
+            const result = sort({ string: 'myArray' }, 'asc');
+            expect(result.toString()).to.equal(`sort(myArray, 'asc')`);
+        });
     });
 
     describe('uniq', (): void => {


### PR DESCRIPTION
This PR proposes adding support for the optional `order` argument on the `sort()` array expression, so descending sorts can be expressed. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/287. You can sign in with your GitHub ID to claim ownership of the project.

## What this changes and why

expr-lang's `sort` builtin accepts an optional second argument, `order`, which is either `'asc'` or `'desc'` (see the expr-lang language definition: `sort([3, 1, 4], "desc") == [4, 3, 1]`). juno's `sort()` helper, however, only accepted the array, so there was no way to generate a descending sort expression. This is also internally inconsistent: juno's own `sortBy()` already exposes the same `order` argument (`sortBy(array, predicate, 'desc')`), so `sort()` was the odd one out.

The change adds an optional `order?: 'asc' | 'desc'` parameter to `sort()`, mirroring the existing `sortBy()` implementation exactly (including the single-quote wrapping juno uses for such literals elsewhere). It is backward-compatible: the argument is optional and omitting it produces the previous output unchanged.

Reproduction on `main` at HEAD — a descending sort simply cannot be expressed today. Calling `sort()` with a second argument fails to type-check:

```
$ npx mocha test/api/expressions/_repro.test.ts
Exception during run: test/api/expressions/_repro.test.ts(5,47): error TS2554: Expected 1 arguments, but got 2.
```

Verification — I ran the full suite on a clean `main` checkout (baseline: 608 passing, 0 failing) and again with the change (610 passing, 0 failing: the 2 additions are the new `sort` order cases). No previously-passing test changed state. The new tests assert the generated strings and fail without the code change (the TS2554 above), and the three existing `sort()` tests continue to pass, covering the backward-compatible no-`order` path:

```
sort
  ✔ returns successfully if expressionArg
  ✔ returns successfully if string
  ✔ returns successfully if fromJson expression
  ✔ returns successfully with descending order
  ✔ returns successfully with ascending order
```

## How this was managed

We imported your issues and pull requests into a live board (283 stories, 5 labels) and used it to manage this work. This specific change was tracked as a story you can view here: https://eastagiletracker.com/projects/287/stories/180359 — and the full board is at https://eastagiletracker.com/projects/287.

![board](https://raw.githubusercontent.com/eastagiletracker/juno/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
